### PR TITLE
alteração do sistema para o Laravel 11; Mudado a variável de "admins" para "admin" no Gate

### DIFF
--- a/app/Http/Controllers/CddController.php
+++ b/app/Http/Controllers/CddController.php
@@ -28,7 +28,7 @@ class CddController extends Controller
      */
     public function create()
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         return view('cdd.create',[
             'cdd' => new Cdd,
         ]);
@@ -42,7 +42,7 @@ class CddController extends Controller
      */
     public function store(CddRequest $request)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $validated = $request->validated();
         $cdd = Cdd::create($validated);
         request()->session()->flash('alert-info','CDD cadastrado com sucesso');
@@ -70,7 +70,7 @@ class CddController extends Controller
      */
     public function edit(Cdd $cdd)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         return view('cdd.edit',[
             'cdd' => $cdd
         ]);
@@ -85,7 +85,7 @@ class CddController extends Controller
      */
     public function update(CddRequest $request, Cdd $cdd)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $validated = $request->validated();
         $cdd->update($validated);
         request()->session()->flash('alert-info','CDD atualizado com sucesso');
@@ -100,7 +100,7 @@ class CddController extends Controller
      */
     public function destroy(Cdd $cdd)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $cdd->delete();
         request()->session()->flash('alert-info','CDD excluído com sucesso.');
         return redirect('/');

--- a/app/Http/Controllers/RemissivaController.php
+++ b/app/Http/Controllers/RemissivaController.php
@@ -16,7 +16,7 @@ class RemissivaController extends Controller
      */
     public function store(RemissivaRequest $request)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $validated = $request->validated();
         $remissiva = Remissiva::create($validated);
         request()->session()->flash('alert-info','Remissiva adicionada com sucesso');
@@ -30,7 +30,7 @@ class RemissivaController extends Controller
      */
     public function destroy(Remissiva $remissiva)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $termo_id = $remissiva->termo_id;
         $remissiva->delete();
         request()->session()->flash('alert-danger','Remissiva foi excluída.');

--- a/app/Http/Controllers/TermoController.php
+++ b/app/Http/Controllers/TermoController.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Builder;
 use App\Services\TermoService;
 use App\Services\RemissivaService;
 use App\Http\Requests\SearchCDDRequest;
+use Illuminate\Support\Facades\Gate;
 
 class TermoController extends Controller
 {
@@ -35,7 +36,7 @@ class TermoController extends Controller
      */
     public function create()
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         return view('termo.create',[
             'termo' => new termo,
         ]);
@@ -49,7 +50,7 @@ class TermoController extends Controller
      */
     public function store(TermoRequest $request)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $termo = Termo::create($request->validated());
 
         foreach(array_filter($request->cdds) as $cdd) {
@@ -85,7 +86,7 @@ class TermoController extends Controller
     public function edit(Termo $termo)
     {
         $termo->load('cdds', 'remissivas');
-        $this->authorize('admins');
+        $this->authorize('admin');
         return view('termo.edit',[
             'termo' => $termo,
         ]);
@@ -100,7 +101,7 @@ class TermoController extends Controller
      */
     public function update(TermoRequest $request, Termo $termo)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $termo->update($request->validated());
 
         $cdd_ids = array();
@@ -127,7 +128,7 @@ class TermoController extends Controller
      */
     public function destroy(Termo $termo)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $termo->delete();
         request()->session()->flash('alert-info','Registro excluído com sucesso.');
         return redirect('/');
@@ -135,7 +136,7 @@ class TermoController extends Controller
 
     public function addCdd(Request $request, Termo $termo)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $cdd = Cdd::where('id',$request->cdd)->first();
         $termo->cdds()->attach($cdd);
         return redirect("/termos/$termo->id");
@@ -143,7 +144,7 @@ class TermoController extends Controller
 
     public function removeCdd(Request $request, Termo $termo, Cdd $cdd)
     {
-        $this->authorize('admins');
+        $this->authorize('admin');
         $termo->cdds()->detach($cdd->id);
         request()->session()->flash('alert-danger', "{$cdd->cdd} foi excluído(a) de {$termo->assunto}");
         return redirect("/termos/{$termo->id}");

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use Fideloper\Proxy\TrustProxies as Middleware;
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 
 class TrustProxies extends Middleware
@@ -19,5 +19,10 @@ class TrustProxies extends Middleware
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+    protected $headers =
+    Request::HEADER_X_FORWARDED_FOR |
+    Request::HEADER_X_FORWARDED_HOST |
+    Request::HEADER_X_FORWARDED_PORT |
+    Request::HEADER_X_FORWARDED_PROTO |
+    Request::HEADER_X_FORWARDED_AWS_ELB;
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        //'App\Models\Model' => 'App\Policies\ModelPolicy',
     ];
 
     /**
@@ -23,11 +23,10 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->registerPolicies();
+
         Gate::define('admin', function ($user) {
-            return false;
             $admins = explode(',', trim(env('SENHAUNICA_ADMINS')));
-            return ( in_array($user->username, $admins) and $user->username );
+            return ( in_array($user->username, $admins) and !empty($user->username) );
         });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,27 +8,25 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.3",
         "barryvdh/laravel-debugbar": "^3.5",
-        "doctrine/dbal": "^3.4",
-        "fideloper/proxy": "^4.2",
-        "fruitcake/laravel-cors": "^2.0",
+        "doctrine/dbal": "^3.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^8.0",
+        "laravel/framework": "^11.0",
         "laravel/tinker": "^2.0",
-        "laravel/ui": "^3.2",
+        "laravel/ui": "^4.0",
         "owen-it/laravel-auditing": "^13.0",
-        "rap2hpoutre/laravel-log-viewer": "^1.7",
+        "rap2hpoutre/laravel-log-viewer": "^2.4.0",
         "uspdev/laravel-usp-faker": "^1.0",
         "uspdev/laravel-usp-theme": "^2.0",
         "uspdev/senhaunica-socialite": "^4.0"
     },
     "require-dev": {
-        "facade/ignition": "^2.3.6",
+        "spatie/laravel-ignition": "^2.0",
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.3.1",
-        "nunomaduro/collision": "^5.0",
-        "phpunit/phpunit": "^9.3"
+        "nunomaduro/collision": "^8.1",
+        "phpunit/phpunit": "^10.0"
     },
     "config": {
         "optimize-autoloader": true,
@@ -52,7 +50,7 @@
             "Tests\\": "tests/"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {
         "post-autoload-dump": [

--- a/config/database.php
+++ b/config/database.php
@@ -63,6 +63,26 @@ return [
             ]) : [],
         ],
 
+        'mariadb' => [
+            'driver' => 'mariadb',
+            'url' => env('DB_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => env('DB_CHARSET', 'utf8mb4'),
+            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
         'pgsql' => [
             'driver' => 'pgsql',
             'url' => env('DATABASE_URL'),
@@ -74,7 +94,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-            'schema' => 'public',
+            'search_path' => 'public',
             'sslmode' => 'prefer',
         ],
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('FILESYSTEM_DRIVER', 'local'),
+    'default' => env('FILESYSTEM_DISK', 'local'),
 
     /*
     |--------------------------------------------------------------------------
@@ -53,6 +53,7 @@ return [
             'root' => storage_path('app/public'),
             'url' => env('APP_URL').'/storage',
             'visibility' => 'public',
+            'throw' => true,
         ],
 
         's3' => [

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -25,7 +25,7 @@ $right_menu = [
         'target' => '_blank',
         'url' => config('app.url') . '/logs',
         'align' => 'right',
-        'can' => 'admins',
+        'can' => 'admin',
     ],
     [
         'text' => '<i class="fas fa-users"></i>',
@@ -33,7 +33,7 @@ $right_menu = [
         'target' => '_blank',
         'url' => config('app.url') . '/users',
         'align' => 'right',
-        'can' => 'admins',
+        'can' => 'admin',
     ],
 ];
 

--- a/resources/views/cdd/partials/fields.blade.php
+++ b/resources/views/cdd/partials/fields.blade.php
@@ -6,7 +6,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item" ><h6>CDD</h6><a href="/cdd/{{$cdd->id}}">{{  $cdd->cdd ?? ''  }}</a></li>  
         </ul>
-        @can('admins')
+        @can('admin')
         </br>
         <div class="col-sm form-group">
             <form action="/cdd/{{  $cdd->id  }}" method="POST">

--- a/resources/views/termo/edit.blade.php
+++ b/resources/views/termo/edit.blade.php
@@ -119,7 +119,7 @@
   </form>
   <div class = "card">
     <div class = "card-body">
-      <b>Data de Criação: </b>{{  old('created_at', $termo->created_at) }}<br>
+      <b>Data de Criação</b> {{ date('d/m/Y H:i', strtotime($termo->created_at))}}<br>
       <br><b>Alterações no termo</b>
       @include('partials.audit.index', ['model' => $termo])
     </div>

--- a/resources/views/termo/partials/fields.blade.php
+++ b/resources/views/termo/partials/fields.blade.php
@@ -1,6 +1,6 @@
 <tr>
   <td>
-    @can('admins')
+    @can('admin')
       <a href="/termos/{{ $termo->id }}/edit">{{  $termo->assunto ?? ''  }}</a>
     @else
       {{  $termo->assunto ?? ''  }}
@@ -23,7 +23,7 @@
   <td>{{  $termo->categoria ?? ''  }}</td>
   <td>{{  $termo->observacao ?? ''  }}</td>
   <td class="text-center">
-    @can('admins')
+    @can('admin')
     <a href="/termos/{{ $termo->id }}" class="delete-item btn text-danger"><i class="fas fa-trash-alt"></i></a>
     @endcan
   </td>

--- a/resources/views/termo/show.blade.php
+++ b/resources/views/termo/show.blade.php
@@ -35,7 +35,7 @@
           <td>{{  $termo->categoria ?? ''  }}</td>
           <td>{{  $termo->observacao ?? ''  }}</td>
           <td class="text-center">
-            @can('admins')
+            @can('admin')
             <form action="/termos/{{  $termo->id  }}" method="POST">
                 @csrf
                 @method('delete')


### PR DESCRIPTION
Ao atualizar o sistema para laravel 11, o admin cadastrado no env não conseguia ter acesso às páginas que estavam com "$this->authorize('admins');" no Controller. Mudei, então, de 'admins' para 'admin', para ficar igual ao Gate.